### PR TITLE
KSP Implementation for XType

### DIFF
--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
@@ -20,6 +20,7 @@ import androidx.room.compiler.processing.javac.JavacExecutableElement
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
@@ -50,6 +51,14 @@ internal fun TypeMirror.safeTypeName(): TypeName = if (kind == TypeKind.NONE) {
 fun TypeSpec.Builder.addOriginatingElement(element: XElement) {
     if (element is JavacElement) {
         this.addOriginatingElement(element.element)
+    }
+}
+
+internal fun TypeName.rawTypeName() : TypeName {
+    return if (this is ParameterizedTypeName) {
+        this.rawType
+    } else {
+        this
     }
 }
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XType.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XType.kt
@@ -139,7 +139,8 @@ interface XType {
     fun isTypeOf(other: KClass<*>): Boolean
 
     /**
-     * Returns `true` if this represents the same type as [other]
+     * Returns `true` if this represents the same type as [other].
+     * TODO: decide on how we want to handle nullability here.
      */
     fun isSameType(other: XType): Boolean
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSTypeExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSTypeExt.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.ksp.symbol.KSType
 import org.jetbrains.kotlin.ksp.symbol.KSTypeReference
 
 // catch-all type name when we cannot resolve to anything.
-private val UNDEFINED = ClassName.get("androidx.room.compiler.processing.kotlin.error", "Undefined")
+internal val UNDEFINED = ClassName.get("androidx.room.compiler.processing.kotlin.error", "Undefined")
 
 /**
  * Turns a KSTypeReference into a TypeName
@@ -77,7 +77,7 @@ private fun KSDeclaration.typeName(): ClassName? {
     return ClassName.get(pkg, shortNames.first(), *(shortNames.drop(1).toTypedArray()))
 }
 
-private fun KSType.typeName(): TypeName? {
+internal fun KSType.typeName(): TypeName? {
     return if (this.arguments.isNotEmpty()) {
         val args: Array<TypeName> = this.arguments.map {
             it.type.typeName()
@@ -102,4 +102,11 @@ private fun KSDeclaration.safeGetPackageName() : String? {
     } catch (t : Throwable) {
         null
     }
+}
+
+// TODO remove after https://github.com/android/kotlin/issues/123
+internal fun KSType?.isAssignableFromWithErrorWorkaround(other:KSType?): Boolean {
+    if (other == null || this == null) return false
+    if (isError || other.isError) return false
+    return isAssignableFrom(other)
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
@@ -40,6 +40,8 @@ internal class KspProcessingEnv(
     override val filer: Filer
         get() = TODO("Not yet implemented")
 
+    val commonTypes = CommonTypes(resolver)
+
     override fun findTypeElement(qName: String): XTypeElement? {
         TODO("Not yet implemented")
     }
@@ -72,5 +74,17 @@ internal class KspProcessingEnv(
         return KspType(
             env = this,
             ksTypeReference = ksTypeReference)
+    }
+
+    class CommonTypes(resolver: Resolver) {
+        val nullableInt by lazy {
+            resolver.builtIns.intType.makeNullable()
+        }
+        val nullableLong by lazy {
+            resolver.builtIns.longType.makeNullable()
+        }
+        val nullableByte by lazy {
+            resolver.builtIns.byteType.makeNullable()
+        }
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
@@ -25,6 +25,8 @@ import androidx.room.compiler.processing.XTypeElement
 import org.jetbrains.kotlin.ksp.processing.CodeGenerator
 import org.jetbrains.kotlin.ksp.processing.KSPLogger
 import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.KSType
+import org.jetbrains.kotlin.ksp.symbol.KSTypeReference
 import javax.annotation.processing.Filer
 
 internal class KspProcessingEnv(
@@ -43,7 +45,9 @@ internal class KspProcessingEnv(
     }
 
     override fun findType(qName: String): XType? {
-        TODO("Not yet implemented")
+        return resolver.findClass(qName)?.let {
+            wrap(it.asStarProjectedType())
+        }
     }
 
     override fun findGeneratedAnnotation(): XTypeElement? {
@@ -56,5 +60,17 @@ internal class KspProcessingEnv(
 
     override fun getArrayType(type: XType): XArrayType {
         TODO("Not yet implemented")
+    }
+
+    fun wrap(ksType: KSType): KspType {
+        return KspType(
+            env = this,
+            resolved = ksType)
+    }
+
+    fun wrap(ksTypeReference: KSTypeReference): KspType {
+        return KspType(
+            env = this,
+            ksTypeReference = ksTypeReference)
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRawType.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRawType.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.ksp
+
+import androidx.room.compiler.processing.XRawType
+import androidx.room.compiler.processing.rawTypeName
+import com.squareup.javapoet.TypeName
+import org.jetbrains.kotlin.ksp.symbol.KSType
+
+internal class KspRawType private constructor(
+    private val ksType: KSType?,
+    override val typeName: TypeName
+) : XRawType {
+    constructor(original: KspType)  :this(
+        ksType = original.ksType?.starProjection(),
+        typeName = original.typeName.rawTypeName()
+    )
+    override fun isAssignableFrom(other: XRawType): Boolean {
+        check(other is KspRawType)
+        return when {
+            other.ksType == null -> this == other
+            ksType == null -> false
+            else -> ksType.isAssignableFrom(other.ksType)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other || typeName == (other as? XRawType)?.typeName
+    }
+
+    override fun hashCode(): Int {
+        return typeName.hashCode()
+    }
+}

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRawType.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRawType.kt
@@ -32,8 +32,7 @@ internal class KspRawType private constructor(
     override fun isAssignableFrom(other: XRawType): Boolean {
         check(other is KspRawType)
         return when {
-            other.ksType == null -> this == other
-            ksType == null -> false
+            other.ksType == null || ksType == null -> this == other
             else -> ksType.isAssignableFrom(other.ksType)
         }
     }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspType.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspType.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.ksp
+
+import androidx.room.compiler.processing.XDeclaredType
+import androidx.room.compiler.processing.XEquality
+import androidx.room.compiler.processing.XNullability
+import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.rawTypeName
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.TypeName
+import org.jetbrains.kotlin.ksp.symbol.KSClassDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSType
+import org.jetbrains.kotlin.ksp.symbol.KSTypeReference
+import org.jetbrains.kotlin.ksp.symbol.Nullability
+import kotlin.reflect.KClass
+
+internal class KspType private constructor(
+    private val env: KspProcessingEnv,
+    private val ksTypeReference: KSTypeReference?,
+    resolved: KSType?
+) : XDeclaredType, XEquality {
+    constructor(env: KspProcessingEnv, ksTypeReference: KSTypeReference) : this(
+        env = env,
+        ksTypeReference = ksTypeReference,
+        resolved = null
+    )
+    constructor(env: KspProcessingEnv, resolved: KSType) : this(
+        env = env,
+        ksTypeReference = null,
+        resolved = resolved
+    )
+    internal val ksType by lazy {
+        resolved ?: ksTypeReference?.resolve()
+    }
+    override val rawType by lazy {
+        KspRawType(this)
+    }
+    override val typeArguments: List<XType> by lazy {
+        val args = ksTypeReference?.element?.typeArguments ?: resolved?.arguments ?: emptyList()
+        args.map {
+            // TODO what if it.type is null?
+            env.wrap(it.type!!)
+        }
+    }
+    override val typeName: TypeName by lazy {
+        ksType?.typeName() ?: ksTypeReference?.typeName() ?: UNDEFINED
+    }
+    override val nullability by lazy {
+        when(ksType?.nullability) {
+            Nullability.NULLABLE -> XNullability.NULLABLE
+            Nullability.NOT_NULL -> XNullability.NONNULL
+            else -> XNullability.UNKNOWN
+        }
+    }
+
+    override fun asTypeElement(): XTypeElement {
+        TODO("elements are not implemented yet")
+    }
+
+    override fun isAssignableFrom(other: XType): Boolean {
+        check(other is KspType)
+        return ksType.isAssignableFromWithErrorWorkaround(other.ksType)
+    }
+
+    override fun isError(): Boolean {
+        return ksType == null || ksType!!.isError
+    }
+
+    override fun defaultValue(): String {
+        val type = ksType ?: return "null"
+        if (type.nullability == Nullability.NULLABLE) {
+            return "null"
+        }
+        val builtIns = env.resolver.builtIns
+        return when(type) {
+            builtIns.booleanType -> "false"
+            builtIns.byteType, builtIns.shortType, builtIns.intType, builtIns.longType, builtIns
+                .charType -> "0"
+            builtIns.floatType -> "0f"
+            builtIns.doubleType -> "0.0"
+            else -> "null"
+        }
+    }
+
+    override fun boxed(): XType {
+        return this
+    }
+
+    override fun isInt(): Boolean {
+        return ksType.isAssignableFromWithErrorWorkaround(env.resolver.builtIns.intType)
+    }
+
+    override fun isLong(): Boolean {
+        return ksType.isAssignableFromWithErrorWorkaround(env.resolver.builtIns.longType)
+    }
+
+    override fun isByte(): Boolean {
+        return ksType.isAssignableFromWithErrorWorkaround(env.resolver.builtIns.byteType)
+    }
+
+    override fun isNone(): Boolean {
+        return ksType == null
+    }
+
+    override fun isType(): Boolean {
+        return ksType != null && ksType!!.declaration is KSClassDeclaration
+    }
+
+    override fun isTypeOf(other: KClass<*>): Boolean {
+        // closest to what MoreTypes#isTypeOf does.
+        return rawType.typeName.toString() == other.qualifiedName
+    }
+
+    override fun isSameType(other: XType): Boolean {
+        check(other is KspType)
+        // NOTE: this is inconsistent with java where nullability is ignored.
+        // it is intentional but might be reversed if it happens to break use cases.
+        return ksType != null && ksType == other.ksType
+    }
+
+    override fun extendsBound(): XType? {
+        // NOTE: wildcard does not fully exist in kotlin and when we resolve, it always seems to
+        // be mapped to the upper bound. Might still need more investigation here
+        // https://kotlinlang.org/docs/reference/generics.html#star-projections
+        return null
+    }
+
+    override val equalityItems: Array<out Any?> by lazy {
+        arrayOf(ksType)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return XEquality.equals(this, other)
+    }
+
+    override fun hashCode(): Int {
+        return XEquality.hashCode(equalityItems)
+    }
+
+    override fun toString(): String {
+        return ksType?.toString() ?: ksTypeReference?.toString() ?: super.toString()
+    }
+}

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspType.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspType.kt
@@ -62,7 +62,7 @@ internal class KspType private constructor(
         KspRawType(this)
     }
     override val typeArguments: List<XType> by lazy {
-        // prioritize type reference if it exists as it will have actaul types user picked.
+        // prioritize type reference if it exists as it will have actual types user picked.
         val args = ksTypeReference?.element?.typeArguments
             ?: resolved?.arguments
             ?: emptyList()
@@ -118,15 +118,15 @@ internal class KspType private constructor(
     }
 
     override fun isInt(): Boolean {
-        return ksType.isAssignableFromWithErrorWorkaround(env.resolver.builtIns.intType)
+        return env.commonTypes.nullableInt.isAssignableFromWithErrorWorkaround(ksType)
     }
 
     override fun isLong(): Boolean {
-        return ksType.isAssignableFromWithErrorWorkaround(env.resolver.builtIns.longType)
+        return env.commonTypes.nullableLong.isAssignableFromWithErrorWorkaround(ksType)
     }
 
     override fun isByte(): Boolean {
-        return ksType.isAssignableFromWithErrorWorkaround(env.resolver.builtIns.byteType)
+        return env.commonTypes.nullableByte.isAssignableFromWithErrorWorkaround(ksType)
     }
 
     override fun isNone(): Boolean {

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspTypeTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspTypeTest.kt
@@ -16,21 +16,14 @@
 
 package androidx.room.compiler.processing.ksp
 
-import androidx.room.compiler.processing.XNullability
 import androidx.room.compiler.processing.XNullability.NONNULL
 import androidx.room.compiler.processing.XNullability.NULLABLE
-import androidx.room.compiler.processing.XType
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.TestInvocation
 import androidx.room.compiler.processing.util.runKspTest
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import com.squareup.javapoet.ClassName
-import com.squareup.javapoet.TypeName
 import org.jetbrains.kotlin.ksp.getDeclaredFunctions
-import org.jetbrains.kotlin.ksp.getDeclaredProperties
-import org.jetbrains.kotlin.ksp.symbol.KSDeclaration
-import org.jetbrains.kotlin.ksp.symbol.KSFunctionDeclaration
 import org.jetbrains.kotlin.ksp.symbol.KSPropertyDeclaration
 import org.jetbrains.kotlin.ksp.symbol.KSTypeReference
 import org.junit.Test
@@ -407,8 +400,8 @@ class KspTypeTest {
         ) { invocation ->
             val env = (invocation.processingEnv as KspProcessingEnv)
             val classNames = listOf("Bar", "Bar_NullableFoo")
-            val typeArgs = classNames.associate {
-                it to env.resolver.findClass(it)!!
+            val typeArgs = classNames.associateWith {
+                env.resolver.findClass(it)!!
                     .asStarProjectedType()
                     .arguments
                     .single()
@@ -470,15 +463,6 @@ class KspTypeTest {
             }
         }
         throw IllegalStateException("cannot find any property with name $name")
-    }
-
-    private fun TestInvocation.requireMethod(name: String): KSFunctionDeclaration {
-        (processingEnv as KspProcessingEnv).resolver.getAllFiles().forEach { file ->
-            return file.declarations.first {
-                it.simpleName.asString() == name
-            } as KSFunctionDeclaration
-        }
-        throw IllegalStateException("cannot find any method with name $name")
     }
 
     private fun TestInvocation.wrap(typeRef: KSTypeReference): KspType {

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspTypeTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspTypeTest.kt
@@ -1,0 +1,487 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.ksp
+
+import androidx.room.compiler.processing.XNullability
+import androidx.room.compiler.processing.XNullability.NONNULL
+import androidx.room.compiler.processing.XNullability.NULLABLE
+import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.TestInvocation
+import androidx.room.compiler.processing.util.runKspTest
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.TypeName
+import org.jetbrains.kotlin.ksp.getDeclaredFunctions
+import org.jetbrains.kotlin.ksp.getDeclaredProperties
+import org.jetbrains.kotlin.ksp.symbol.KSDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSFunctionDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSPropertyDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSTypeReference
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class KspTypeTest {
+    @Test
+    fun assignability() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            package foo.bar;
+            class Baz : AbstractClass(), MyInterface {
+            }
+            abstract class AbstractClass {}
+            interface MyInterface {}
+        """.trimIndent()
+        )
+        runKspTest(listOf(src), succeed = true) {
+            val subject = it.processingEnv.requireType("foo.bar.Baz")
+            assertThat(subject.typeName).isEqualTo(
+                ClassName.get("foo.bar", "Baz")
+            )
+            // basic assertions for abstract class
+            val abstractSubject = it.processingEnv.requireType("foo.bar.AbstractClass")
+            // basic assertions for interface declaration
+            val interfaceSubject = it.processingEnv.requireType("foo.bar.MyInterface")
+            // check assignability
+            assertThat(
+                interfaceSubject.isAssignableFrom(
+                    abstractSubject
+                )
+            ).isFalse()
+            assertThat(
+                interfaceSubject.isAssignableFrom(
+                    subject
+                )
+            ).isTrue()
+            assertThat(
+                abstractSubject.isAssignableFrom(
+                    subject
+                )
+            ).isTrue()
+        }
+    }
+
+    @Test
+    fun errorType() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            package foo.bar;
+            val errorType : IDontExist = TODO()
+            val listOfErrorType : List<IDontExist> = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = false
+        ) { invocation ->
+            invocation.requirePropertyType("errorType").let { type ->
+                assertThat(type.isError()).isTrue()
+                assertThat(type.typeArguments).isEmpty()
+                assertThat(type.typeName).isEqualTo(ClassName.bestGuess("IDontExist"))
+            }
+
+            invocation.requirePropertyType("listOfErrorType").let { type ->
+                assertThat(type.isError()).isFalse()
+                assertThat(type.typeArguments).hasSize(1)
+                type.typeArguments.single().let { typeArg ->
+                    assertThat(typeArg.isError()).isTrue()
+                    assertThat(typeArg.typeName).isEqualTo(ClassName.bestGuess("IDontExist"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun typeArguments() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            package foo.bar;
+            val listOfNullableStrings : List<String?> = TODO()
+            val listOfInts : List<Int> = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            invocation.requirePropertyType("listOfNullableStrings").let { type ->
+                assertThat(type.nullability).isEqualTo(NONNULL)
+                assertThat(type.typeArguments).hasSize(1)
+                type.typeArguments.single().let { typeArg ->
+                    assertThat(typeArg.nullability).isEqualTo(NULLABLE)
+                    assertThat(
+                        typeArg.isAssignableFrom(
+                            invocation.processingEnv.requireType("kotlin.String")
+                        )
+                    ).isTrue()
+                }
+            }
+
+            invocation.requirePropertyType("listOfInts").let { type ->
+                assertThat(type.nullability).isEqualTo(NONNULL)
+                assertThat(type.typeArguments).hasSize(1)
+                type.typeArguments.single().let { typeArg ->
+                    assertThat(typeArg.nullability).isEqualTo(NONNULL)
+                    assertThat(
+                        typeArg.isAssignableFrom(
+                            invocation.processingEnv.requireType("kotlin.Int")
+                        )
+                    ).isTrue()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun equality() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            package foo.bar;
+            val listOfNullableStrings : List<String?> = TODO()
+            val listOfNullableStrings_2 : List<String?> = TODO()
+            val listOfNonNullStrings : List<String> = TODO()
+            val listOfNonNullStrings_2 : List<String> = TODO()
+            val nullableString : String? = TODO()
+            val nonNullString : String = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            val nullableStringList = invocation.requirePropertyType("listOfNullableStrings")
+            val nonNullStringList = invocation.requirePropertyType("listOfNonNullStrings")
+            assertThat(nullableStringList).isNotEqualTo(nonNullStringList)
+            assertThat(nonNullStringList).isNotEqualTo(nullableStringList)
+
+            val nullableStirngList_2 = invocation.requirePropertyType("listOfNullableStrings_2")
+            val nonNullStringList_2 = invocation.requirePropertyType("listOfNonNullStrings_2")
+            assertThat(nullableStringList).isEqualTo(nullableStirngList_2)
+            assertThat(nonNullStringList).isEqualTo(nonNullStringList_2)
+
+            val nullableString = invocation.requirePropertyType("nullableString")
+            val nonNullString = invocation.requirePropertyType("nonNullString")
+            assertThat(nullableString).isEqualTo(
+                nullableStringList.typeArguments.single()
+            )
+            assertThat(nullableString).isNotEqualTo(
+                nonNullStringList.typeArguments.single()
+            )
+            assertThat(nonNullString).isEqualTo(
+                nonNullStringList.typeArguments.single()
+            )
+            assertThat(nonNullString).isNotEqualTo(
+                nullableStringList.typeArguments.single()
+            )
+        }
+    }
+
+    @Test
+    fun rawType() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            package foo.bar;
+            val simple : Int = 0
+            val list : List<String> = TODO()
+            val map : Map<String, String> = TODO()
+            val listOfMaps : List<Map<String, String>> = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            invocation.requirePropertyType("simple").let {
+                assertThat(it.rawType.typeName).isEqualTo(ClassName.get("kotlin", "Int"))
+            }
+            invocation.requirePropertyType("list").let { list ->
+                assertThat(list.rawType).isNotEqualTo(list)
+                assertThat(list.typeArguments).isNotEmpty()
+                assertThat(list.rawType.typeName)
+                    .isEqualTo(ClassName.get("kotlin.collections", "List"))
+            }
+            invocation.requirePropertyType("map").let { map ->
+                assertThat(map.rawType).isNotEqualTo(map)
+                assertThat(map.typeArguments).hasSize(2)
+                assertThat(map.rawType.typeName)
+                    .isEqualTo(ClassName.get("kotlin.collections", "Map"))
+            }
+            invocation.requirePropertyType("listOfMaps").let { listOfMaps ->
+                assertThat(listOfMaps.rawType).isNotEqualTo(listOfMaps)
+                assertThat(listOfMaps.typeArguments).hasSize(1)
+            }
+        }
+    }
+
+    @Test
+    fun isTypeChecks() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            val intProp : Int = 0
+            val nullableIntProp : Int? = null
+            val longProp : Long = 0
+            val nullableLongProp : Long? = null
+            val byteProp : Byte = 0
+            val nullableByteProp :Byte? = null
+            val errorProp : IDontExist = TODO()
+            val nullableErrorProp : IDontExist? = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = false
+        ) { invocation ->
+            fun mapProp(name: String) = invocation.requirePropertyType(name).let {
+                listOf(
+                    "isInt" to it.isInt(),
+                    "isLong" to it.isLong(),
+                    "isByte" to it.isByte(),
+                    "isError" to it.isError(),
+                    "isNone" to it.isNone()
+                ).filter {
+                    it.second
+                }.map {
+                    it.first
+                }
+            }
+            assertThat(mapProp("intProp")).containsExactly("isInt")
+            assertThat(mapProp("nullableIntProp")).containsExactly("isInt")
+            assertThat(mapProp("longProp")).containsExactly("isLong")
+            assertThat(mapProp("nullableLongProp")).containsExactly("isLong")
+            assertThat(mapProp("byteProp")).containsExactly("isByte")
+            assertThat(mapProp("nullableByteProp")).containsExactly("isByte")
+            assertThat(mapProp("errorProp")).containsExactly("isError")
+            assertThat(mapProp("nullableErrorProp")).containsExactly("isError")
+        }
+    }
+
+    @Test
+    fun defaultValue() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            val intProp : Int = 3 // kotlin default value is unrelated, will be ignored
+            val nullableIntProp : Int? = null
+            val longProp : Long = 3
+            val nullableLongProp : Long? = null
+            val floatProp = 3f
+            val byteProp : Byte = 0
+            val nullableByteProp :Byte? = null
+            val errorProp : IDontExist = TODO()
+            val nullableErrorProp : IDontExist? = TODO()
+            val stringProp : String = "abc"
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = false
+        ) { invocation ->
+            fun getDefaultValue(name: String) = invocation.requirePropertyType(name).defaultValue()
+            // javac types do not check nullability but checking it is more correct
+            // since KSP is an opt-in by the developer, it is better for it to be more strict about
+            // types.
+            assertThat(getDefaultValue("intProp")).isEqualTo("0")
+            assertThat(getDefaultValue("nullableIntProp")).isEqualTo("null")
+            assertThat(getDefaultValue("longProp")).isEqualTo("0")
+            assertThat(getDefaultValue("nullableLongProp")).isEqualTo("null")
+            assertThat(getDefaultValue("floatProp")).isEqualTo("0f")
+            assertThat(getDefaultValue("byteProp")).isEqualTo("0")
+            assertThat(getDefaultValue("nullableByteProp")).isEqualTo("null")
+            assertThat(getDefaultValue("errorProp")).isEqualTo("null")
+            assertThat(getDefaultValue("nullableErrorProp")).isEqualTo("null")
+            assertThat(getDefaultValue("stringProp")).isEqualTo("null")
+        }
+    }
+
+    @Test
+    fun isTypeOf() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            val intProp : Int = 3
+            val longProp : Long = 3
+            val stringProp : String = "abc"
+            val listProp : List<String> = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            assertThat(
+                invocation.requirePropertyType("stringProp").isTypeOf(
+                    String::class
+                )
+            ).isTrue()
+            assertThat(
+                invocation.requirePropertyType("intProp").isTypeOf(
+                    Int::class
+                )
+            ).isTrue()
+            assertThat(
+                invocation.requirePropertyType("longProp").isTypeOf(
+                    Long::class
+                )
+            ).isTrue()
+            assertThat(
+                invocation.requirePropertyType("listProp").isTypeOf(
+                    List::class
+                )
+            ).isTrue()
+            assertThat(
+                invocation.requirePropertyType("listProp").isTypeOf(
+                    Set::class
+                )
+            ).isFalse()
+            assertThat(
+                invocation.requirePropertyType("listProp").isTypeOf(
+                    Iterable::class
+                )
+            ).isFalse()
+        }
+    }
+
+    @Test
+    fun isSameType() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            val intProp : Int = 3
+            val intProp2 : Int = 4
+            val longProp : Long = 0L
+            val nullableLong : Long? = null
+            val listOfStrings1 : List<String> = TODO()
+            val listOfStrings2 : List<String> = TODO()
+            val listOfInts : List<Int> = TODO()
+            val listOfNullableStrings : List<String?> = TODO()
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            fun check(prop1: String, prop2: String): Boolean {
+                return invocation.requirePropertyType(prop1).isSameType(
+                    invocation.requirePropertyType(prop2)
+                )
+            }
+            assertThat(check("intProp", "intProp2")).isTrue()
+            assertThat(check("intProp2", "intProp")).isTrue()
+            assertThat(check("intProp", "longProp")).isFalse()
+            // incompatible w/ java
+            assertThat(check("longProp", "nullableLong")).isFalse()
+            assertThat(check("listOfStrings1", "listOfStrings2")).isTrue()
+            assertThat(check("listOfStrings1", "listOfNullableStrings")).isFalse()
+            assertThat(check("listOfInts", "listOfStrings2")).isFalse()
+        }
+    }
+
+    @Suppress("MapGetWithNotNullAssertionOperator")
+    @Test
+    fun extendsBounds() {
+        val src = Source.kotlin(
+            "foo.kt", """
+            open class Foo;
+            class Bar<T : Foo> {
+            }
+            class Bar_NullableFoo<T : Foo?>
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            val env = (invocation.processingEnv as KspProcessingEnv)
+            val classNames = listOf("Bar", "Bar_NullableFoo")
+            val typeArgs = classNames.associate {
+                it to env.resolver.findClass(it)!!
+                    .asStarProjectedType()
+                    .arguments
+                    .single()
+                    .type
+                    .let {
+                        invocation.wrap(typeRef = it!!)
+                    }
+            }
+            assertThat(typeArgs["Bar"]!!.typeName)
+                .isEqualTo(ClassName.get("", "Foo"))
+            assertThat(typeArgs["Bar"]!!.nullability).isEqualTo(NONNULL)
+            assertThat(typeArgs["Bar_NullableFoo"]!!.typeName)
+                .isEqualTo(ClassName.get("", "Foo"))
+            assertThat(typeArgs["Bar_NullableFoo"]!!.nullability).isEqualTo(NULLABLE)
+        }
+    }
+
+
+    @Test
+    fun wildcardJava() {
+        val src = Source.java(
+            "foo.bar.Baz", """
+            package foo.bar;
+            import java.util.List;
+            public class Baz {
+                private void wildcardMethod(List<? extends Number> list) {
+                } 
+            }
+        """.trimIndent()
+        )
+        runKspTest(
+            listOf(src),
+            succeed = true
+        ) { invocation ->
+            val env = (invocation.processingEnv as KspProcessingEnv)
+            val method = env.resolver
+                .findClass("foo.bar.Baz")
+                ?.getDeclaredFunctions()
+                ?.first {
+                    it.simpleName.asString() == "wildcardMethod"
+                } ?: throw AssertionError("cannot find test method")
+            val paramType = invocation.wrap(method.parameters.first().type!!)
+            val arg1 = paramType.typeArguments.single()
+            assertThat(arg1.typeName)
+                .isEqualTo(ClassName.get("kotlin", "Number"))
+            assertThat(arg1.extendsBound()).isNull()
+        }
+    }
+
+    private fun TestInvocation.requirePropertyType(name: String): KspType {
+        (processingEnv as KspProcessingEnv).resolver.getAllFiles().forEach { file ->
+            val prop = file.declarations.first {
+                it.simpleName.asString() == name
+            } as KSPropertyDeclaration
+            return checkNotNull(prop.type?.let {
+                wrap(it)
+            }) {
+                "cannot find type for $name"
+            }
+        }
+        throw IllegalStateException("cannot find any property with name $name")
+    }
+
+    private fun TestInvocation.requireMethod(name: String): KSFunctionDeclaration {
+        (processingEnv as KspProcessingEnv).resolver.getAllFiles().forEach { file ->
+            return file.declarations.first {
+                it.simpleName.asString() == name
+            } as KSFunctionDeclaration
+        }
+        throw IllegalStateException("cannot find any method with name $name")
+    }
+
+    private fun TestInvocation.wrap(typeRef: KSTypeReference): KspType {
+        return (processingEnv as KspProcessingEnv).wrap(typeRef)
+    }
+}

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspTypeTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspTypeTest.kt
@@ -419,7 +419,6 @@ class KspTypeTest {
         }
     }
 
-
     @Test
     fun wildcardJava() {
         val src = Source.java(

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
@@ -128,7 +128,7 @@ fun runProcessorTest(
     }
 
     // now run with ksp
-    //runKspTest(sources, succeed = true, handler = handler)
+    runKspTest(sources, succeed = true, handler = handler)
 }
 
 fun runKspTest(

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
@@ -128,7 +128,7 @@ fun runProcessorTest(
     }
 
     // now run with ksp
-    runKspTest(sources, succeed = true, handler = handler)
+    //runKspTest(sources, succeed = true, handler = handler)
 }
 
 fun runKspTest(


### PR DESCRIPTION
This is a limited implementation of XType for KSP.

It is mostly complete but there are some questionable cases where we cannot decide what to do now.
There are `NOTE` s in the code for them. Especially how we'll handle nullability is difficult to decide until we can run the full engine and hit different use cases.

Instead of using XType's tests, this PR brings its own tests as we need deeper testing for KSP (in other words, we don't have auto-common)